### PR TITLE
Add basic PyTorch modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
 Mixture-of-Experts Variational Autoencoder for Clustering and Generating from Similarity-Based Representations on Single Cell Data
 
 ## Install conda environment
-```
+```bash
 conda env create -f spec-file.yml
 conda activate moesimvae
 ```
 
 ## Run MoE-Sim-VAE on scRNA-sequencing data clustering mouse organs
-```
+```bash
 cd src
 python run_cluster_mouse_organs.py --dir_output PATH/TO/OUTPUT_DIRECTORY --loss_coef_kl_div_code_standard_gaussian 0.2 --loss_coef_clustering 0.8
+```
+
+## PyTorch version
+A basic PyTorch implementation is provided in the `torch_src` directory. You can run a toy example with:
+```bash
+cd torch_src
+python run_cluster_mouse_organs.py
 ```

--- a/torch_src/decoder.py
+++ b/torch_src/decoder.py
@@ -1,0 +1,39 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Expert(nn.Module):
+    def __init__(self, code_size, output_size, hidden_size,
+                 activation=nn.ReLU(), depth=1):
+        super().__init__()
+        layers = []
+        in_features = code_size
+        for _ in range(depth):
+            layers.append(nn.Linear(in_features, hidden_size))
+            layers.append(activation)
+            in_features = hidden_size
+        layers.append(nn.Linear(in_features, output_size))
+        self.mlp = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.mlp(x)
+
+
+class Decoder(nn.Module):
+    """Mixture of Experts decoder in PyTorch."""
+
+    def __init__(self, num_experts, code_size, output_size, hidden_size,
+                 activation=nn.ReLU(), depth=1):
+        super().__init__()
+        self.experts = nn.ModuleList([
+            Expert(code_size, output_size, hidden_size, activation, depth)
+            for _ in range(num_experts)
+        ])
+        self.gate = nn.Linear(code_size, num_experts)
+
+    def forward(self, code):
+        gates = F.softmax(self.gate(code), dim=-1)
+        outputs = torch.stack([expert(code) for expert in self.experts], dim=1)
+        weighted = torch.einsum('bn,bnd->bd', gates, outputs)
+        return weighted, gates

--- a/torch_src/encoder.py
+++ b/torch_src/encoder.py
@@ -1,0 +1,31 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Encoder(nn.Module):
+    """Simple variational encoder implemented in PyTorch."""
+
+    def __init__(self, input_size, code_size, hidden_size,
+                 activation=nn.ReLU(), depth=1, dropout=0.5):
+        super().__init__()
+        layers = []
+        in_features = input_size
+        for _ in range(depth):
+            layers.append(nn.Linear(in_features, hidden_size))
+            layers.append(activation)
+            layers.append(nn.Dropout(dropout))
+            in_features = hidden_size
+        self.mlp = nn.Sequential(*layers)
+        self.fc_loc = nn.Linear(in_features, code_size)
+        self.fc_log_scale = nn.Linear(in_features, code_size)
+
+    def forward(self, x):
+        x = x.view(x.size(0), -1)
+        h = self.mlp(x)
+        loc = self.fc_loc(h)
+        log_scale = self.fc_log_scale(h)
+        scale = torch.exp(log_scale)
+        eps = torch.randn_like(scale)
+        code = loc + eps * scale
+        return code, loc, scale

--- a/torch_src/run_cluster_mouse_organs.py
+++ b/torch_src/run_cluster_mouse_organs.py
@@ -1,0 +1,46 @@
+"""Simplified training script using PyTorch modules."""
+import argparse
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, TensorDataset
+from .encoder import Encoder
+from .decoder import Decoder
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PyTorch MoE-Sim-VAE example")
+    parser.add_argument('--num_markers', type=int, default=100)
+    parser.add_argument('--code_size', type=int, default=20)
+    parser.add_argument('--hidden_size', type=int, default=100)
+    parser.add_argument('--num_experts', type=int, default=7)
+    parser.add_argument('--batch_size', type=int, default=32)
+    parser.add_argument('--epochs', type=int, default=10)
+    parser.add_argument('--learning_rate', type=float, default=1e-3)
+    args = parser.parse_args()
+
+    # Placeholder random data - replace with real dataset
+    data = torch.rand(1000, args.num_markers)
+    dataloader = DataLoader(TensorDataset(data), batch_size=args.batch_size, shuffle=True)
+
+    encoder = Encoder(input_size=args.num_markers, code_size=args.code_size,
+                      hidden_size=args.hidden_size)
+    decoder = Decoder(num_experts=args.num_experts, code_size=args.code_size,
+                      output_size=args.num_markers, hidden_size=args.hidden_size)
+    optim = torch.optim.Adam(list(encoder.parameters()) + list(decoder.parameters()),
+                             lr=args.learning_rate)
+
+    for epoch in range(args.epochs):
+        for batch, in dataloader:
+            code, loc, scale = encoder(batch)
+            recon, gates = decoder(code)
+            recon_loss = F.binary_cross_entropy_with_logits(recon, batch, reduction='mean')
+            kl = -0.5 * torch.mean(1 + torch.log(scale ** 2) - loc ** 2 - scale ** 2)
+            loss = recon_loss + kl
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+        print(f"Epoch {epoch+1}: loss={loss.item():.4f}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add initial PyTorch-based encoder and decoder implementations
- create a simple PyTorch training script
- update README with instructions for running the PyTorch version

## Testing
- `python -m py_compile torch_src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68526daa1ad483338d40e26e4901c128